### PR TITLE
Updated README to reference the 2020 BlueZ CVE. Fixed the order of macOS and iOS headings.

### DIFF
--- a/cve-2023-45866/README.md
+++ b/cve-2023-45866/README.md
@@ -22,7 +22,7 @@ The vulnerabilities work by tricking the Bluetooth host state-machine into pairi
 
 The vulnerabilities can be exploited from a Linux computer using a standard Bluetooth adapter. Once the attacker has paired with the target phone or computer, they can inject keystrokes to perform arbitrary actions as the victim, provided those actions don't require a password or biometric authentication.
 
-Some of the vulnerabilities predate MouseJack, and I was able to reproduce keystroke-injection on Android back to version 4.2.2, which was released in 2012. The Linux vulnerability was fixed in 2020, but the fix was left disabled by default. ChromeOS is the only Linux-based OS known to have enabled the fix, even though it was announced by Ubuntu, Debian, Fedora, Gentoo, Arch and Alpine.
+Some of the vulnerabilities predate MouseJack, and I was able to reproduce keystroke-injection on Android back to version 4.2.2, which was released in 2012. The Linux vulnerability was fixed in 2020 (CVE-2020-0556), but the fix was left disabled by default. ChromeOS is the only Linux-based OS known to have enabled the fix, even though it was announced by Ubuntu, Debian, Fedora, Gentoo, Arch and Alpine. The BlueZ patch for CVE-2023-45866 enables the 2020 fix by default.
 
 I only tested recent versions of macOS and iOS, and am not privy to the full scope or history of the Apple vulnerabilities.
 
@@ -72,7 +72,7 @@ The attack does not require specialized hardware, and can be performed from a Li
   - 2023-10-02 - case opened with CERT/CC
   - 2023-12-06 - public disclosure
 
-#### iOS
+#### macOS
 
 - The following devices were tested and found vulnerable:
   - 2022 MacBook Pro with MacOS 13.3.3 (M2)
@@ -82,7 +82,7 @@ The attack does not require specialized hardware, and can be performed from a Li
   - 2023-08-01 - vulnerability reported to Apple
   - 2023-12-06 - public disclosure
 
-##### macOS
+##### iOS
 
 - The following devices were tested and found vulnerable:
   - iPhone SE running iOS 16.6


### PR DESCRIPTION
- Added CVE-2020-0556 for context on the Linux vulnerability. This CVE was fixed in 2020, but the fix was disabled by default. The BlueZ fix for CVE-2023-45866 enables the CVE-2020-0556 fix by default.
- Fixed the ordering of iOS and macOS headers, which were swapped.