### PR TITLE
added links to information Ubuntu published regarding the CVE and fix

### DIFF
--- a/cve-2023-45866/README.md
+++ b/cve-2023-45866/README.md
@@ -65,7 +65,11 @@ The attack does not require specialized hardware, and can be performed from a Li
 - The following Ubuntu versions were tested and found vulnerable.
   - Ubuntu 18.04, 20.04, 22.04, 23.10
 - Per Google, ChromeOS is not vulnerable. I did not test ChromeOS, but their BlueZ configuration does appear to mitigate the vulnerability
-- The following patch mitigates the vulnerability in BlueZ: https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/profiles/input?id=25a471a83e02e1effb15d5a488b3f0085eaeb675
+- The following patch mitigates the vulnerability in BlueZ
+  - https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/profiles/input?id=25a471a83e02e1effb15d5a488b3f0085eaeb675
+- Details regarding the vulnerability and fix from Ubuntu:
+  - https://ubuntu.com/security/CVE-2023-45866
+  - https://ubuntu.com/security/notices/USN-6540-1
 - Disclosure Timeline
   - 2023-08-10 - vulnerability reported to Canonical
   - 2023-09-25 - vulnerability reported to Bluetooth SIG


### PR DESCRIPTION
This PR adds the following two links to the blog post:

https://ubuntu.com/security/CVE-2023-45866
https://ubuntu.com/security/notices/USN-6540-1